### PR TITLE
nRF5SDK 17.0.0

### DIFF
--- a/nRF5SDK/components/ble/ble_services/ble_dfu/ble_dfu.c
+++ b/nRF5SDK/components/ble/ble_services/ble_dfu/ble_dfu.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/ble_services/ble_dfu/ble_dfu.h
+++ b/nRF5SDK/components/ble/ble_services/ble_dfu/ble_dfu.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/ble_services/ble_dfu/ble_dfu_bonded.c
+++ b/nRF5SDK/components/ble/ble_services/ble_dfu/ble_dfu_bonded.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/ble_services/ble_dfu/ble_dfu_unbonded.c
+++ b/nRF5SDK/components/ble/ble_services/ble_dfu/ble_dfu_unbonded.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/ble_services/ble_dis/ble_dis.c
+++ b/nRF5SDK/components/ble/ble_services/ble_dis/ble_dis.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/ble_services/ble_dis/ble_dis.h
+++ b/nRF5SDK/components/ble/ble_services/ble_dis/ble_dis.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/common/ble_advdata.c
+++ b/nRF5SDK/components/ble/common/ble_advdata.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -628,7 +628,7 @@ uint16_t ble_advdata_search(uint8_t const * p_encoded_data,
 
     uint16_t i = 0;
 
-    while (((i < *p_offset) || (p_encoded_data[i + 1] != ad_type)) && (i < data_len))
+    while ((i + 1 < data_len) && ((i < *p_offset) || (p_encoded_data[i + 1] != ad_type)))
     {
         // Jump to next data.
         i += (p_encoded_data[i] + 1);
@@ -641,10 +641,10 @@ uint16_t ble_advdata_search(uint8_t const * p_encoded_data,
     else
     {
         uint16_t offset = i + 2;
-        uint16_t len    = p_encoded_data[i] - 1;
-        if ((offset + len) > data_len)
+        uint16_t len    = p_encoded_data[i] ? (p_encoded_data[i] - 1) : 0;
+        if (!len || ((offset + len) > data_len))
         {
-            // Malformed. Extends beyond provided data.
+            // Malformed. Zero length or extends beyond provided data.
             return 0;
         }
         *p_offset = offset;

--- a/nRF5SDK/components/ble/common/ble_advdata.h
+++ b/nRF5SDK/components/ble/common/ble_advdata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/common/ble_conn_params.c
+++ b/nRF5SDK/components/ble/common/ble_conn_params.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/common/ble_conn_params.h
+++ b/nRF5SDK/components/ble/common/ble_conn_params.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/common/ble_conn_state.c
+++ b/nRF5SDK/components/ble/common/ble_conn_state.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -239,10 +239,16 @@ static void ble_evt_handler(ble_evt_t const * p_ble_evt, void * p_context)
                 // No more records available. Should not happen.
                 APP_ERROR_HANDLER(NRF_ERROR_NO_MEM);
             }
-            else if ((p_ble_evt->evt.gap_evt.params.connected.role != BLE_GAP_ROLE_PERIPH))
+#ifdef BLE_GAP_ROLE_CENTRAL
+            else if ((p_ble_evt->evt.gap_evt.params.connected.role == BLE_GAP_ROLE_CENTRAL))
             {
                 // Central
                 nrf_atflags_set(&m_bcs.flags.central_flags, conn_handle);
+            }
+#endif // BLE_GAP_ROLE_CENTRAL
+            else
+            {
+                // No implementation required.
             }
 
             break;
@@ -290,12 +296,14 @@ uint8_t ble_conn_state_role(uint16_t conn_handle)
 
     if (ble_conn_state_valid(conn_handle))
     {
-#if !defined(S112) && !defined(S312) && !defined(S113)
+#if defined (BLE_GAP_ROLE_PERIPH) && defined (BLE_GAP_ROLE_CENTRAL)
         bool central = nrf_atflags_get(&m_bcs.flags.central_flags, conn_handle);
         role = central ? BLE_GAP_ROLE_CENTRAL : BLE_GAP_ROLE_PERIPH;
+#elif defined (BLE_GAP_ROLE_CENTRAL)
+        role = BLE_GAP_ROLE_CENTRAL;
 #else
         role = BLE_GAP_ROLE_PERIPH;
-#endif // !defined (S112) && !defined(S312) && !defined(S113)
+#endif // defined (BLE_GAP_ROLE_PERIPH) && defined (BLE_GAP_ROLE_CENTRAL)
     }
 
     return role;

--- a/nRF5SDK/components/ble/common/ble_conn_state.h
+++ b/nRF5SDK/components/ble/common/ble_conn_state.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/common/ble_date_time.h
+++ b/nRF5SDK/components/ble/common/ble_date_time.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2011 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/common/ble_gatt_db.h
+++ b/nRF5SDK/components/ble/common/ble_gatt_db.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/common/ble_sensor_location.h
+++ b/nRF5SDK/components/ble/common/ble_sensor_location.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/common/ble_srv_common.c
+++ b/nRF5SDK/components/ble/common/ble_srv_common.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/common/ble_srv_common.h
+++ b/nRF5SDK/components/ble/common/ble_srv_common.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/nrf_ble_gatt/nrf_ble_gatt.c
+++ b/nRF5SDK/components/ble/nrf_ble_gatt/nrf_ble_gatt.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -63,14 +63,14 @@ static void link_init(nrf_ble_gatt_link_t * p_link)
     p_link->att_mtu_effective          = BLE_GATT_ATT_MTU_DEFAULT;
     p_link->att_mtu_exchange_pending   = false;
     p_link->att_mtu_exchange_requested = false;
-#if !defined (S112) && !defined(S312)
+#if !defined (S112) && !defined(S312) && !defined (S122)
     p_link->data_length_desired        = NRF_SDH_BLE_GAP_DATA_LENGTH;
     p_link->data_length_effective      = BLE_GAP_DATA_LENGTH_DEFAULT;
-#endif // !defined (S112) && !defined(S312)
+#endif // !defined (S112) && !defined(S312) && !defined (S122)
 }
 
 /**@brief   Start a data length update request procedure on a given connection. */
-#if !defined (S112) && !defined(S312)
+#if !defined (S112) && !defined(S312) && !defined(S122)
 static ret_code_t data_length_update(uint16_t conn_handle, uint16_t data_length)
 {
     NRF_LOG_DEBUG("Updating data length to %u on connection 0x%x.",
@@ -109,7 +109,7 @@ static ret_code_t data_length_update(uint16_t conn_handle, uint16_t data_length)
 
     return err_code;
 }
-#endif // !defined (S112) && !defined(S312)
+#endif // !defined (S112) && !defined(S312) && !defined (S122)
 
 
 /**@brief Handle a connected event.
@@ -126,15 +126,17 @@ static void on_connected_evt(nrf_ble_gatt_t * p_gatt, ble_evt_t const * p_ble_ev
     nrf_ble_gatt_link_t * p_link      = &p_gatt->links[conn_handle];
 
     // Update the link desired settings to reflect the current global settings.
-#if !defined (S112) && !defined(S312)
+#if !defined (S112) && !defined(S312) && !defined(S122)
     p_link->data_length_desired = p_gatt->data_length;
-#endif // !defined (S112) && !defined(S312)
+#endif // !defined (S112) && !defined(S312) && !defined (S122)
 
     switch (p_ble_evt->evt.gap_evt.params.connected.role)
     {
+#if !defined (S122)
         case BLE_GAP_ROLE_PERIPH:
             p_link->att_mtu_desired = p_gatt->att_mtu_desired_periph;
             break;
+#endif // !defined (S122)
 
 #if !defined (S112) && !defined(S312) && !defined(S113)
         case BLE_GAP_ROLE_CENTRAL:
@@ -172,13 +174,13 @@ static void on_connected_evt(nrf_ble_gatt_t * p_gatt, ble_evt_t const * p_ble_ev
         }
     }
 
-#if !defined (S112) && !defined(S312)
+#if !defined (S112) && !defined(S312) && !defined (S122)
     // Send a data length update request if necessary.
     if (p_link->data_length_desired > p_link->data_length_effective)
     {
         (void) data_length_update(conn_handle, p_link->data_length_desired);
     }
-#endif // !defined (S112) && !defined(S312)
+#endif // !defined (S112) && !defined(S312) && !defined (S122)
 }
 
 
@@ -292,7 +294,7 @@ static void on_exchange_mtu_request_evt(nrf_ble_gatt_t * p_gatt, ble_evt_t const
  * @param[in]   p_gatt      GATT structure.
  * @param[in]   p_ble_evt   Event received from the BLE stack.
  */
-#if !defined (S112) && !defined(S312)
+#if !defined (S112) && !defined(S312) && !defined (S122)
 static void on_data_length_update_evt(nrf_ble_gatt_t * p_gatt, ble_evt_t const * p_ble_evt)
 {
     ble_gap_evt_t const gap_evt     = p_ble_evt->evt.gap_evt;
@@ -361,7 +363,7 @@ static void on_data_length_update_request_evt(nrf_ble_gatt_t * p_gatt, ble_evt_t
 
     (void) data_length_update(p_gap_evt->conn_handle, data_length_effective);
 }
-#endif // !defined (S112) && !defined(S312)
+#endif // !defined (S112) && !defined(S312) && !defined (S122)
 
 
 ret_code_t nrf_ble_gatt_init(nrf_ble_gatt_t * p_gatt, nrf_ble_gatt_evt_handler_t evt_handler)
@@ -420,7 +422,7 @@ uint16_t nrf_ble_gatt_eff_mtu_get(nrf_ble_gatt_t const * p_gatt, uint16_t conn_h
     return p_gatt->links[conn_handle].att_mtu_effective;
 }
 
-#if !defined (S112) && !defined(S312)
+#if !defined (S112) && !defined(S312) && !defined (S122)
 ret_code_t nrf_ble_gatt_data_length_set(nrf_ble_gatt_t * p_gatt,
                                         uint16_t         conn_handle,
                                         uint8_t          data_length)
@@ -479,7 +481,7 @@ ret_code_t nrf_ble_gatt_data_length_get(nrf_ble_gatt_t const * p_gatt,
     *p_data_length = p_gatt->links[conn_handle].data_length_effective;
     return NRF_SUCCESS;
 }
-#endif // !defined (S112) && !defined(S312)
+#endif // !defined (S112) && !defined(S312) && !defined(S122)
 
 
 void nrf_ble_gatt_on_ble_evt(ble_evt_t const * p_ble_evt, void * p_context)
@@ -510,7 +512,7 @@ void nrf_ble_gatt_on_ble_evt(ble_evt_t const * p_ble_evt, void * p_context)
             on_exchange_mtu_request_evt(p_gatt, p_ble_evt);
             break;
 
-#if !defined (S112) && !defined(S312)
+#if !defined (S112) && !defined(S312) && !defined (S122)
         case BLE_GAP_EVT_DATA_LENGTH_UPDATE:
             on_data_length_update_evt(p_gatt, p_ble_evt);
             break;
@@ -518,7 +520,7 @@ void nrf_ble_gatt_on_ble_evt(ble_evt_t const * p_ble_evt, void * p_context)
         case BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST:
             on_data_length_update_request_evt(p_gatt, p_ble_evt);
             break;
-#endif // !defined (S112) && !defined(S312)
+#endif // !defined (S112) && !defined(S312) && !defined (S122)
 
         default:
             break;

--- a/nRF5SDK/components/ble/nrf_ble_gatt/nrf_ble_gatt.h
+++ b/nRF5SDK/components/ble/nrf_ble_gatt/nrf_ble_gatt.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/auth_status_tracker.c
+++ b/nRF5SDK/components/ble/peer_manager/auth_status_tracker.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/auth_status_tracker.h
+++ b/nRF5SDK/components/ble/peer_manager/auth_status_tracker.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/gatt_cache_manager.c
+++ b/nRF5SDK/components/ble/peer_manager/gatt_cache_manager.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/gatt_cache_manager.h
+++ b/nRF5SDK/components/ble/peer_manager/gatt_cache_manager.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/gatts_cache_manager.c
+++ b/nRF5SDK/components/ble/peer_manager/gatts_cache_manager.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/gatts_cache_manager.h
+++ b/nRF5SDK/components/ble/peer_manager/gatts_cache_manager.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/id_manager.c
+++ b/nRF5SDK/components/ble/peer_manager/id_manager.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/id_manager.h
+++ b/nRF5SDK/components/ble/peer_manager/id_manager.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/nrf_ble_lesc.h
+++ b/nRF5SDK/components/ble/peer_manager/nrf_ble_lesc.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/peer_data_storage.c
+++ b/nRF5SDK/components/ble/peer_manager/peer_data_storage.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -550,6 +550,9 @@ ret_code_t pds_peer_data_store(pm_peer_id_t                 peer_id,
 
         case FDS_ERR_NO_SPACE_IN_FLASH:
             return NRF_ERROR_STORAGE_FULL;
+
+        case FDS_ERR_UNALIGNED_ADDR:
+            return NRF_ERROR_INVALID_ADDR;
 
         default:
             NRF_LOG_ERROR("Could not write data to flash. fds_record_{write|update}() returned 0x%x. "\

--- a/nRF5SDK/components/ble/peer_manager/peer_data_storage.h
+++ b/nRF5SDK/components/ble/peer_manager/peer_data_storage.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -138,6 +138,7 @@ bool pds_peer_data_iterate(pm_peer_data_id_t            data_id,
  *
  * @retval NRF_SUCCESS              If the operation was initiated successfully.
  * @retval NRF_ERROR_INVALID_PARAM  If @p peer_id or the data ID in @p_peer_data are invalid.
+ * @retval NRF_ERROR_INVALID_ADDR   If @p p_peer_data is not word-aligned.
  * @retval NRF_ERROR_STORAGE_FULL   If no space is available in flash.
  * @retval NRF_ERROR_BUSY           If the flash filesystem was busy.
  * @retval NRF_ERROR_INTERNAL       If an unexpected error occurred.

--- a/nRF5SDK/components/ble/peer_manager/peer_database.c
+++ b/nRF5SDK/components/ble/peer_manager/peer_database.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/peer_database.h
+++ b/nRF5SDK/components/ble/peer_manager/peer_database.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/peer_id.c
+++ b/nRF5SDK/components/ble/peer_manager/peer_id.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/peer_id.h
+++ b/nRF5SDK/components/ble/peer_manager/peer_id.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/peer_manager.c
+++ b/nRF5SDK/components/ble/peer_manager/peer_manager.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -951,6 +951,7 @@ ret_code_t pm_peer_new(pm_peer_id_t           * p_new_peer_id,
 
         // NRF_ERROR_STORAGE_FULL, if no space in flash.
         // NRF_ERROR_BUSY,         if flash filesystem was busy.
+        // NRF_ERROR_INVALID_ADDR, if bonding data is unaligned.
         // NRF_ERROR_INTENRAL,     on internal error.
         return err_code;
     }

--- a/nRF5SDK/components/ble/peer_manager/peer_manager.h
+++ b/nRF5SDK/components/ble/peer_manager/peer_manager.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -453,7 +453,7 @@ bool pm_address_resolve(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * p_i
 /**@brief Function for getting the connection handle of the connection with a bonded peer.
  *
  * @param[in]  peer_id        The peer ID of the bonded peer.
- * @param[out] p_conn_handle  Connection handle, or @ref BLE_ERROR_INVALID_CONN_HANDLE if the peer
+ * @param[out] p_conn_handle  Connection handle, or @ref BLE_CONN_HANDLE_INVALID if the peer
  *                            is not connected.
  *
  * @retval NRF_SUCCESS              If the connection handle was retrieved successfully.
@@ -625,6 +625,7 @@ ret_code_t pm_peer_data_app_data_load(pm_peer_id_t peer_id,
  * @retval NRF_SUCCESS              If the data is scheduled to be written to persistent storage.
  * @retval NRF_ERROR_NULL           If @p p_data is NULL.
  * @retval NRF_ERROR_NOT_FOUND      If no peer was found for the peer ID.
+ * @retval NRF_ERROR_INVALID_ADDR   If @p p_data is not word-aligned (4 bytes).
  * @retval NRF_ERROR_BUSY           If the underlying flash handler is busy with other flash
  *                                  operations. Try again after receiving a Peer Manager event.
  * @retval NRF_ERROR_STORAGE_FULL   If there is not enough space in persistent storage.
@@ -703,6 +704,7 @@ ret_code_t pm_peer_data_delete(pm_peer_id_t peer_id, pm_peer_data_id_t data_id);
  *
  * @retval NRF_SUCCESS              If the store operation for bonding data was initiated successfully.
  * @retval NRF_ERROR_NULL           If @p p_bonding_data or @p p_new_peer_id is NULL.
+ * @retval NRF_ERROR_INVALID_ADDR   If @p p_bonding_data is not word-aligned (4 bytes).
  * @retval NRF_ERROR_STORAGE_FULL   If there is not enough space in persistent storage.
  * @retval NRF_ERROR_NO_MEM         If there are no more available peer IDs.
  * @retval NRF_ERROR_BUSY           If the underlying flash filesystem is busy with other flash

--- a/nRF5SDK/components/ble/peer_manager/peer_manager_handler.c
+++ b/nRF5SDK/components/ble/peer_manager/peer_manager_handler.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/peer_manager_handler.h
+++ b/nRF5SDK/components/ble/peer_manager/peer_manager_handler.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/peer_manager_internal.h
+++ b/nRF5SDK/components/ble/peer_manager/peer_manager_internal.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/peer_manager_types.h
+++ b/nRF5SDK/components/ble/peer_manager/peer_manager_types.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/pm_buffer.c
+++ b/nRF5SDK/components/ble/peer_manager/pm_buffer.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -120,7 +120,7 @@ uint8_t pm_buffer_block_acquire(pm_buffer_t * p_buffer, uint32_t n_blocks)
             {
                 first_locked_mutex = i;
             }
-            if ((uint32_t)(i - first_locked_mutex + 1) == n_blocks)
+            if ((i - first_locked_mutex + 1U) == n_blocks)
             {
                 return first_locked_mutex;
             }

--- a/nRF5SDK/components/ble/peer_manager/pm_buffer.h
+++ b/nRF5SDK/components/ble/peer_manager/pm_buffer.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/security_dispatcher.c
+++ b/nRF5SDK/components/ble/peer_manager/security_dispatcher.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -318,6 +318,7 @@ static void sec_proc_start(uint16_t                conn_handle,
 }
 
 
+#ifdef BLE_GAP_ROLE_PERIPH
 /**@brief Function for processing the @ref BLE_GAP_EVT_SEC_INFO_REQUEST event from the SoftDevice.
  *
  * @param[in]  p_gap_evt  The event from the SoftDevice.
@@ -391,6 +392,7 @@ static void sec_info_request_process(ble_gap_evt_t const * p_gap_evt)
 
     return;
 }
+#endif // BLE_GAP_ROLE_PERIPH
 
 
 /**@brief Function for sending a CONFIG_REQ event.
@@ -465,6 +467,7 @@ static void send_params_req(uint16_t conn_handle, ble_gap_sec_params_t const * p
  */
 static void sec_params_request_process(ble_gap_evt_t const * p_gap_evt)
 {
+#ifdef BLE_GAP_ROLE_PERIPH
     if (ble_conn_state_role(p_gap_evt->conn_handle) == BLE_GAP_ROLE_PERIPH)
     {
         sec_proc_start(p_gap_evt->conn_handle,
@@ -473,6 +476,7 @@ static void sec_params_request_process(ble_gap_evt_t const * p_gap_evt)
                                                ? PM_CONN_SEC_PROCEDURE_BONDING
                                                : PM_CONN_SEC_PROCEDURE_PAIRING);
     }
+#endif // BLE_GAP_ROLE_PERIPH
 
     send_params_req(p_gap_evt->conn_handle, &p_gap_evt->params.sec_params_request.peer_params);
     return;
@@ -796,11 +800,13 @@ ret_code_t smd_params_reply(uint16_t                 conn_handle,
     ble_gap_sec_keyset_t sec_keyset;
 
     memset(&sec_keyset, 0, sizeof(ble_gap_sec_keyset_t));
+#ifdef BLE_GAP_ROLE_PERIPH
     if (role == BLE_GAP_ROLE_PERIPH)
     {
         // Set the default value for allowing repairing at the start of the sec proc. (for peripheral)
         ble_conn_state_user_flag_set(conn_handle, m_flag_allow_repairing, false);
     }
+#endif // BLE_GAP_ROLE_PERIPH
 
     if (role == BLE_GAP_ROLE_INVALID)
     {
@@ -821,6 +827,7 @@ ret_code_t smd_params_reply(uint16_t                 conn_handle,
     }
     else
     {
+#ifdef BLE_GAP_ROLE_PERIPH
         if ((im_peer_id_get_by_conn_handle(conn_handle) != PM_PEER_ID_INVALID) &&
             (role == BLE_GAP_ROLE_PERIPH) &&
             !allow_repairing(conn_handle))
@@ -833,6 +840,7 @@ ret_code_t smd_params_reply(uint16_t                 conn_handle,
                 sec_status = BLE_GAP_SEC_STATUS_PAIRING_NOT_SUPP;
             }
         }
+#endif // BLE_GAP_ROLE_PERIPH
 
         if (!p_sec_params->bond)
         {
@@ -851,14 +859,13 @@ ret_code_t smd_params_reply(uint16_t                 conn_handle,
     {
         // Everything OK, reply to SoftDevice. If an error happened, the user is given an
         // opportunity to change the parameters and retry the call.
-        if (role == BLE_GAP_ROLE_PERIPH)
-        {
-            err_code = sd_ble_gap_sec_params_reply(conn_handle, sec_status, p_sec_params, &sec_keyset);
-        }
-        else
-        {
-            err_code = sd_ble_gap_sec_params_reply(conn_handle, sec_status, NULL, &sec_keyset);
-        }
+
+        ble_gap_sec_params_t * p_aux_sec_params = NULL;
+#ifdef BLE_GAP_ROLE_PERIPH
+        p_aux_sec_params = (role == BLE_GAP_ROLE_PERIPH) ? p_sec_params : NULL;
+#endif // BLE_GAP_ROLE_PERIPH
+
+        err_code = sd_ble_gap_sec_params_reply(conn_handle, sec_status, p_aux_sec_params, &sec_keyset);
     }
 
     return err_code;
@@ -1010,6 +1017,7 @@ static void sec_request_process(ble_gap_evt_t const * p_gap_evt)
 #endif // PM_CENTRAL_ENABLED
 
 
+#ifdef BLE_GAP_ROLE_PERIPH
 /**@brief Function for asking the central to secure the link. See @ref smd_link_secure for more info.
  */
 static ret_code_t link_secure_peripheral(uint16_t conn_handle, ble_gap_sec_params_t * p_sec_params)
@@ -1023,6 +1031,7 @@ static ret_code_t link_secure_peripheral(uint16_t conn_handle, ble_gap_sec_param
 
     return err_code;
 }
+#endif
 
 
 ret_code_t smd_link_secure(uint16_t conn_handle,
@@ -1040,8 +1049,10 @@ ret_code_t smd_link_secure(uint16_t conn_handle,
             return link_secure_central(conn_handle, p_sec_params, force_repairing);
 #endif
 
+#ifdef BLE_GAP_ROLE_PERIPH
         case BLE_GAP_ROLE_PERIPH:
             return link_secure_peripheral(conn_handle, p_sec_params);
+#endif // BLE_GAP_ROLE_PERIPH
 
         default:
             return BLE_ERROR_INVALID_CONN_HANDLE;
@@ -1061,9 +1072,11 @@ void smd_ble_evt_handler(ble_evt_t const * p_ble_evt)
             sec_params_request_process(&(p_ble_evt->evt.gap_evt));
             break;
 
+#ifdef BLE_GAP_ROLE_PERIPH
         case BLE_GAP_EVT_SEC_INFO_REQUEST:
             sec_info_request_process(&(p_ble_evt->evt.gap_evt));
             break;
+#endif // BLE_GAP_ROLE_PERIPH
 
 #if PM_CENTRAL_ENABLED
         case BLE_GAP_EVT_SEC_REQUEST:

--- a/nRF5SDK/components/ble/peer_manager/security_dispatcher.h
+++ b/nRF5SDK/components/ble/peer_manager/security_dispatcher.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/security_manager.c
+++ b/nRF5SDK/components/ble/peer_manager/security_manager.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/ble/peer_manager/security_manager.h
+++ b/nRF5SDK/components/ble/peer_manager/security_manager.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/atomic/nrf_atomic.c
+++ b/nRF5SDK/components/libraries/atomic/nrf_atomic.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/atomic/nrf_atomic.h
+++ b/nRF5SDK/components/libraries/atomic/nrf_atomic.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/atomic/nrf_atomic_internal.h
+++ b/nRF5SDK/components/libraries/atomic/nrf_atomic_internal.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/atomic/nrf_atomic_sanity_check.h
+++ b/nRF5SDK/components/libraries/atomic/nrf_atomic_sanity_check.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/atomic_fifo/nrf_atfifo.c
+++ b/nRF5SDK/components/libraries/atomic_fifo/nrf_atfifo.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2011 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/atomic_fifo/nrf_atfifo.h
+++ b/nRF5SDK/components/libraries/atomic_fifo/nrf_atfifo.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2011 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/atomic_fifo/nrf_atfifo_internal.h
+++ b/nRF5SDK/components/libraries/atomic_fifo/nrf_atfifo_internal.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2011 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/atomic_flags/nrf_atflags.c
+++ b/nRF5SDK/components/libraries/atomic_flags/nrf_atflags.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/atomic_flags/nrf_atflags.h
+++ b/nRF5SDK/components/libraries/atomic_flags/nrf_atflags.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/balloc/nrf_balloc.c
+++ b/nRF5SDK/components/libraries/balloc/nrf_balloc.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/balloc/nrf_balloc.h
+++ b/nRF5SDK/components/libraries/balloc/nrf_balloc.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/ble_dfu/nrf_dfu_ble.h
+++ b/nRF5SDK/components/libraries/bootloader/ble_dfu/nrf_dfu_ble.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/ble_dfu/nrf_dfu_ble_svci_bond_sharing.h
+++ b/nRF5SDK/components/libraries/bootloader/ble_dfu/nrf_dfu_ble_svci_bond_sharing.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/dfu-cc.pb.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/dfu-cc.pb.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_flash.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_flash.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_handling_error.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_handling_error.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_mbr.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_mbr.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_req_handler.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_req_handler.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_settings.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_settings.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -196,6 +196,12 @@ bool nrf_dfu_settings_adv_name_is_valid(void);
  */
 ret_code_t nrf_dfu_settings_additional_erase(void);
 
+/** @brief Function for resetting both init command and DFU transfer progress inside settings structure.
+ *
+ * @note    This function does not perform flash operation.
+ *          In order to save the reset state, please use @ref nrf_dfu_settings_write function.
+ */
+void nrf_dfu_settings_progress_reset(void);
 
 #ifdef __cplusplus
 }

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_svci.c
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_svci.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_transport.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_transport.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_types.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_types.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -97,6 +97,8 @@ extern "C" {
     #define BOOTLOADER_SETTINGS_ADDRESS     (0x0002F000UL)
 #elif defined( NRF52811_XXAA )
     #define BOOTLOADER_SETTINGS_ADDRESS     (0x0002F000UL)
+#elif defined( NRF52820_XXAA )
+    #define BOOTLOADER_SETTINGS_ADDRESS     (0x0003F000UL)
 #elif defined( NRF52832_XXAA )
     #define BOOTLOADER_SETTINGS_ADDRESS     (0x0007F000UL)
 #elif defined( NRF52833_XXAA )
@@ -122,6 +124,8 @@ extern "C" {
     #define NRF_MBR_PARAMS_PAGE_ADDRESS         (0x0002E000UL)
 #elif defined(NRF52811_XXAA)
     #define NRF_MBR_PARAMS_PAGE_ADDRESS         (0x0002E000UL)
+#elif defined(NRF52820_XXAA)
+    #define NRF_MBR_PARAMS_PAGE_ADDRESS         (0x0003E000UL)
 #endif
 
 #define BOOTLOADER_SETTINGS_BACKUP_ADDRESS NRF_MBR_PARAMS_PAGE_ADDRESS

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_utils.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_utils.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_validation.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_validation.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_ver_validation.h
+++ b/nRF5SDK/components/libraries/bootloader/dfu/nrf_dfu_ver_validation.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/nrf_bootloader.h
+++ b/nRF5SDK/components/libraries/bootloader/nrf_bootloader.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/nrf_bootloader_app_start.h
+++ b/nRF5SDK/components/libraries/bootloader/nrf_bootloader_app_start.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -54,24 +54,20 @@
 
 /**@brief Function for using hardware to protect flash from writing and reading.
  *
- * @details This function will apply write/erase protection to a specific area. Read
- *          protection is optional, decided by \p read_protect. This function uses
- *          the BPROT or ACL peripheral, depending on which is available.
+ * @details This function applies write/erase protection to a specific area, using the BPROT or ACL
+ *          peripheral, depending on which is available.
  *
  * @param[in]  address       The start address of the area to protect. Must be a flash page
  *                           boundary.
  * @param[in]  size          The size of the area to protect, in bytes. Must be a multiple
  *                           of flash page size.
- * @param[in]  read_protect  Whether to protect the area from reading/executing as well.
- *                           This is not available on chips with the BPROT peripheral
- *                           (e.g. nrf52832, nrf52810).
  *
  * @retval  NRF_SUCCESS              Flash protection applied successfully.
  * @retval  NRF_ERROR_NO_MEM         No more ACL instances to use for flash protection.
  * @retval  NRF_ERROR_INVALID_PARAM  Address was out of range or size was not a multiple
  *                                   of flash page size.
  */
-ret_code_t nrf_bootloader_flash_protect(uint32_t address, uint32_t size, bool read_protect);
+ret_code_t nrf_bootloader_flash_protect(uint32_t address, uint32_t size);
 
 /**@brief Function for starting another application (and aborting the current one).
  *

--- a/nRF5SDK/components/libraries/bootloader/nrf_bootloader_dfu_timers.h
+++ b/nRF5SDK/components/libraries/bootloader/nrf_bootloader_dfu_timers.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/nrf_bootloader_fw_activation.h
+++ b/nRF5SDK/components/libraries/bootloader/nrf_bootloader_fw_activation.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/nrf_bootloader_info.h
+++ b/nRF5SDK/components/libraries/bootloader/nrf_bootloader_info.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/bootloader/nrf_bootloader_wdt.h
+++ b/nRF5SDK/components/libraries/bootloader/nrf_bootloader_wdt.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/crc32/crc32.c
+++ b/nRF5SDK/components/libraries/crc32/crc32.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2013 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/crc32/crc32.h
+++ b/nRF5SDK/components/libraries/crc32/crc32.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/delay/nrf_delay.h
+++ b/nRF5SDK/components/libraries/delay/nrf_delay.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2011 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/experimental_section_vars/nrf_section.h
+++ b/nRF5SDK/components/libraries/experimental_section_vars/nrf_section.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/experimental_section_vars/nrf_section_iter.c
+++ b/nRF5SDK/components/libraries/experimental_section_vars/nrf_section_iter.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/experimental_section_vars/nrf_section_iter.h
+++ b/nRF5SDK/components/libraries/experimental_section_vars/nrf_section_iter.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/fds/fds.c
+++ b/nRF5SDK/components/libraries/fds/fds.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -1092,6 +1092,9 @@ static void gc_swap_pages(void)
     // Keep the offset for this page, but reset it for the swap.
     m_pages[m_gc.cur_page].write_offset = m_swap_page.write_offset;
     m_swap_page.write_offset            = FDS_PAGE_TAG_SIZE;
+
+    // Page has been garbage collected
+    m_pages[m_gc.cur_page].can_gc = false;
 }
 
 

--- a/nRF5SDK/components/libraries/fds/fds.h
+++ b/nRF5SDK/components/libraries/fds/fds.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/fds/fds_internal_defs.h
+++ b/nRF5SDK/components/libraries/fds/fds_internal_defs.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/fstorage/nrf_fstorage.c
+++ b/nRF5SDK/components/libraries/fstorage/nrf_fstorage.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/fstorage/nrf_fstorage.h
+++ b/nRF5SDK/components/libraries/fstorage/nrf_fstorage.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/fstorage/nrf_fstorage_nvmc.h
+++ b/nRF5SDK/components/libraries/fstorage/nrf_fstorage_nvmc.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/fstorage/nrf_fstorage_sd.c
+++ b/nRF5SDK/components/libraries/fstorage/nrf_fstorage_sd.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/fstorage/nrf_fstorage_sd.h
+++ b/nRF5SDK/components/libraries/fstorage/nrf_fstorage_sd.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log.h
+++ b/nRF5SDK/components/libraries/log/nrf_log.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log_backend_flash.h
+++ b/nRF5SDK/components/libraries/log/nrf_log_backend_flash.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log_backend_interface.h
+++ b/nRF5SDK/components/libraries/log/nrf_log_backend_interface.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log_backend_rtt.h
+++ b/nRF5SDK/components/libraries/log/nrf_log_backend_rtt.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log_backend_uart.h
+++ b/nRF5SDK/components/libraries/log/nrf_log_backend_uart.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log_ctrl.h
+++ b/nRF5SDK/components/libraries/log/nrf_log_ctrl.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log_default_backends.h
+++ b/nRF5SDK/components/libraries/log/nrf_log_default_backends.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log_instance.h
+++ b/nRF5SDK/components/libraries/log/nrf_log_instance.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log_str_formatter.h
+++ b/nRF5SDK/components/libraries/log/nrf_log_str_formatter.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/nrf_log_types.h
+++ b/nRF5SDK/components/libraries/log/nrf_log_types.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/src/nrf_log_backend_serial.c
+++ b/nRF5SDK/components/libraries/log/src/nrf_log_backend_serial.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/src/nrf_log_backend_serial.h
+++ b/nRF5SDK/components/libraries/log/src/nrf_log_backend_serial.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/src/nrf_log_ctrl_internal.h
+++ b/nRF5SDK/components/libraries/log/src/nrf_log_ctrl_internal.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/src/nrf_log_frontend.c
+++ b/nRF5SDK/components/libraries/log/src/nrf_log_frontend.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -75,6 +75,14 @@ NRF_RINGBUF_DEF(m_log_push_ringbuf, NRF_LOG_STR_PUSH_BUFFER_SIZE);
 #define NRF_LOG_MAX_BACKENDS           (32/NRF_LOG_FILTER_BITS_PER_BACKEND)
 #define NRF_LOG_MAX_HEXDUMP            (NRF_LOG_MSGPOOL_ELEMENT_SIZE*NRF_LOG_MSGPOOL_ELEMENT_COUNT/2)
 #define NRF_LOG_INVALID_BACKEND_U32    0xFFFFFFFF
+
+/* Mask is extracted from the structure log_data_t to allow compile time initialization which
+ * is needed to allow usage of the logger (logging) before logger is initialized.
+ * It cannot be part of the log_data_t because some compilers would put whole log_data_t structure
+ * into flash (including buffer) just because one field is initilized.
+ */
+static uint32_t m_buffer_mask =  NRF_LOG_BUF_WORDS - 1; // Size of buffer (must be power of 2) presented as mask
+
 /**
  * brief An internal control block of the logger
  *
@@ -85,20 +93,18 @@ NRF_RINGBUF_DEF(m_log_push_ringbuf, NRF_LOG_STR_PUSH_BUFFER_SIZE);
  */
 typedef struct
 {
+    bool                      autoflush;
     uint32_t                  wr_idx;          // Current write index (never reset)
     uint32_t                  rd_idx;          // Current read index  (never_reset)
-    uint32_t                  mask;            // Size of buffer (must be power of 2) presented as mask
     uint32_t                  buffer[NRF_LOG_BUF_WORDS];
     nrf_log_timestamp_func_t  timestamp_func;  // A pointer to function that returns timestamp
     nrf_log_backend_t const * p_backend_head;
     nrf_atomic_flag_t         log_skipping;
     nrf_atomic_flag_t         log_skipped;
     nrf_atomic_u32_t          log_dropped_cnt;
-    bool                      autoflush;
 } log_data_t;
 
 static log_data_t   m_log_data;
-
 
 NRF_LOG_MODULE_REGISTER();
 
@@ -118,17 +124,17 @@ ret_code_t nrf_log_init(nrf_log_timestamp_func_t timestamp_func, uint32_t timest
         return NRF_ERROR_INVALID_PARAM;
     }
 
-    m_log_data.mask         = NRF_LOG_BUF_WORDS - 1;
-    m_log_data.wr_idx       = 0;
-    m_log_data.rd_idx       = 0;
-    m_log_data.log_skipped  = 0;
-    m_log_data.log_skipping = 0;
     m_log_data.autoflush    = NRF_LOG_DEFERRED ? false : true;
+
     if (NRF_LOG_USES_TIMESTAMP)
     {
         nrf_log_str_formatter_timestamp_freq_set(timestamp_freq);
         m_log_data.timestamp_func = timestamp_func;
     }
+
+#ifdef UNIT_TEST
+    m_buffer_mask = NRF_LOG_BUF_WORDS - 1;
+#endif
 
     ret_code_t err_code = nrf_memobj_pool_init(&log_mempool);
     if (err_code != NRF_SUCCESS)
@@ -345,7 +351,7 @@ static uint32_t log_skip(void)
     (void)nrf_atomic_flag_set(&m_log_data.log_skipping);
 
     uint32_t           rd_idx = m_log_data.rd_idx;
-    uint32_t           mask   = m_log_data.mask;
+    uint32_t           mask   = m_buffer_mask;
     nrf_log_header_t * p_header = (nrf_log_header_t *)&m_log_data.buffer[rd_idx & mask];
     nrf_log_header_t   header;
 
@@ -449,7 +455,7 @@ static inline bool buf_prealloc(uint32_t content_len, uint32_t * p_wr_idx, bool 
     bool     ret            = true;
     CRITICAL_REGION_ENTER();
     *p_wr_idx = m_log_data.wr_idx;
-    uint32_t available_words = (m_log_data.mask + 1) - (m_log_data.wr_idx - m_log_data.rd_idx);
+    uint32_t available_words = (m_buffer_mask + 1) - (m_log_data.wr_idx - m_log_data.rd_idx);
     while (req_len > available_words)
     {
         UNUSED_RETURN_VALUE(nrf_atomic_u32_add(&m_log_data.log_dropped_cnt, 1));
@@ -457,7 +463,7 @@ static inline bool buf_prealloc(uint32_t content_len, uint32_t * p_wr_idx, bool 
         {
             uint32_t dropped_in_skip = log_skip();
             UNUSED_RETURN_VALUE(nrf_atomic_u32_add(&m_log_data.log_dropped_cnt, dropped_in_skip));
-            available_words = (m_log_data.mask + 1) - (m_log_data.wr_idx - m_log_data.rd_idx);
+            available_words = (m_buffer_mask + 1) - (m_log_data.wr_idx - m_log_data.rd_idx);
         }
         else
         {
@@ -485,7 +491,7 @@ static inline bool buf_prealloc(uint32_t content_len, uint32_t * p_wr_idx, bool 
         }
 
         nrf_log_main_header_t * p_header =
-                   (nrf_log_main_header_t *)&m_log_data.buffer[m_log_data.wr_idx & m_log_data.mask];
+                   (nrf_log_main_header_t *)&m_log_data.buffer[m_log_data.wr_idx & m_buffer_mask];
 
         p_header->raw = invalid_header.raw;
 
@@ -538,7 +544,7 @@ static inline void std_n(uint32_t           severity_mid,
                          uint32_t const *   args,
                          uint32_t           nargs)
 {
-    uint32_t mask   = m_log_data.mask;
+    uint32_t mask   = m_buffer_mask;
     uint32_t wr_idx;
 
     if (buf_prealloc(nargs, &wr_idx, true))
@@ -647,7 +653,7 @@ void nrf_log_frontend_hexdump(uint32_t           severity_mid,
                               const void * const p_data,
                               uint16_t           length)
 {
-    uint32_t mask   = m_log_data.mask;
+    uint32_t mask   = m_buffer_mask;
 
     uint32_t wr_idx;
     if (buf_prealloc(CEIL_DIV(length, sizeof(uint32_t)), &wr_idx, false))
@@ -655,7 +661,7 @@ void nrf_log_frontend_hexdump(uint32_t           severity_mid,
         uint32_t header_wr_idx = wr_idx;
         wr_idx += HEADER_SIZE;
 
-        uint32_t space0 = sizeof(uint32_t) * (m_log_data.mask + 1 - (wr_idx & mask));
+        uint32_t space0 = sizeof(uint32_t) * (m_buffer_mask + 1 - (wr_idx & mask));
         if (length <= space0)
         {
             memcpy(&m_log_data.buffer[wr_idx & mask], p_data, length);
@@ -718,7 +724,7 @@ bool nrf_log_frontend_dequeue(void)
     //It has to be ensured that reading rd_idx occurs after skipped flag is cleared.
     __DSB();
     uint32_t           rd_idx   = m_log_data.rd_idx;
-    uint32_t           mask     = m_log_data.mask;
+    uint32_t           mask     = m_buffer_mask;
     nrf_log_header_t * p_header = (nrf_log_header_t *)&m_log_data.buffer[rd_idx & mask];
     nrf_log_header_t   header;
     nrf_memobj_t *     p_msg_buf = NULL;

--- a/nRF5SDK/components/libraries/log/src/nrf_log_internal.h
+++ b/nRF5SDK/components/libraries/log/src/nrf_log_internal.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/log/src/nrf_log_str_formatter.c
+++ b/nRF5SDK/components/libraries/log/src/nrf_log_str_formatter.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/memobj/nrf_memobj.c
+++ b/nRF5SDK/components/libraries/memobj/nrf_memobj.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/memobj/nrf_memobj.h
+++ b/nRF5SDK/components/libraries/memobj/nrf_memobj.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/mutex/nrf_mtx.h
+++ b/nRF5SDK/components/libraries/mutex/nrf_mtx.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/pwr_mgmt/nrf_pwr_mgmt.h
+++ b/nRF5SDK/components/libraries/pwr_mgmt/nrf_pwr_mgmt.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/ringbuf/nrf_ringbuf.c
+++ b/nRF5SDK/components/libraries/ringbuf/nrf_ringbuf.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/ringbuf/nrf_ringbuf.h
+++ b/nRF5SDK/components/libraries/ringbuf/nrf_ringbuf.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/sortlist/nrf_sortlist.c
+++ b/nRF5SDK/components/libraries/sortlist/nrf_sortlist.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/sortlist/nrf_sortlist.h
+++ b/nRF5SDK/components/libraries/sortlist/nrf_sortlist.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/strerror/nrf_strerror.c
+++ b/nRF5SDK/components/libraries/strerror/nrf_strerror.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2011 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/strerror/nrf_strerror.h
+++ b/nRF5SDK/components/libraries/strerror/nrf_strerror.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/svc/nrf_svc_function.h
+++ b/nRF5SDK/components/libraries/svc/nrf_svc_function.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/svc/nrf_svci.h
+++ b/nRF5SDK/components/libraries/svc/nrf_svci.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/svc/nrf_svci_async_function.h
+++ b/nRF5SDK/components/libraries/svc/nrf_svci_async_function.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/svc/nrf_svci_async_handler.h
+++ b/nRF5SDK/components/libraries/svc/nrf_svci_async_handler.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/timer/app_timer.h
+++ b/nRF5SDK/components/libraries/timer/app_timer.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/timer/drv_rtc.h
+++ b/nRF5SDK/components/libraries/timer/drv_rtc.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -279,6 +279,16 @@ void drv_rtc_compare_disable(drv_rtc_t const * const p_instance, uint32_t cc);
  * @return True if interrupt pending, false otherwise.
  */
 bool drv_rtc_compare_pending(drv_rtc_t const * const p_instance, uint32_t cc);
+
+/**
+ * @brief Function for reading compare value.
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ * @param[in] cc         Compare channel index.
+ *
+ * @return Compare value set for given channel.
+ */
+uint32_t drv_rtc_compare_get(drv_rtc_t const * const p_instance, uint32_t cc);
 
 /**
  * @brief Function for getting current value of RTC counter.

--- a/nRF5SDK/components/libraries/util/app_error.c
+++ b/nRF5SDK/components/libraries/util/app_error.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/app_error.h
+++ b/nRF5SDK/components/libraries/util/app_error.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2013 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -88,7 +88,7 @@ typedef struct
  */
 typedef struct
 {
-    uint16_t        line_num;    /**< The line number where the error occurred. */
+    uint32_t        line_num;    /**< The line number where the error occurred. */
     uint8_t const * p_file_name; /**< The file in which the error occurred. */
 } assert_info_t;
 

--- a/nRF5SDK/components/libraries/util/app_error_handler_gcc.c
+++ b/nRF5SDK/components/libraries/util/app_error_handler_gcc.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/app_error_weak.c
+++ b/nRF5SDK/components/libraries/util/app_error_weak.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/app_error_weak.h
+++ b/nRF5SDK/components/libraries/util/app_error_weak.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/app_util.h
+++ b/nRF5SDK/components/libraries/util/app_util.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2012 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/app_util_platform.c
+++ b/nRF5SDK/components/libraries/util/app_util_platform.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -95,7 +95,7 @@ uint8_t privilege_level_get(void)
 #if __CORTEX_M == (0x00U) || defined(_WIN32) || defined(__unix) || defined(__APPLE__)
     /* the Cortex-M0 has no concept of privilege */
     return APP_LEVEL_PRIVILEGED;
-#elif __CORTEX_M == (0x04U)
+#elif __CORTEX_M >= (0x04U)
     uint32_t isr_vector_num = __get_IPSR() & IPSR_ISR_Msk ;
     if (0 == isr_vector_num)
     {

--- a/nRF5SDK/components/libraries/util/app_util_platform.h
+++ b/nRF5SDK/components/libraries/util/app_util_platform.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2014 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -72,7 +72,7 @@ extern "C" {
 #define _PRIO_APP_LOW       3
 #define _PRIO_APP_LOWEST    3
 #define _PRIO_THREAD        4
-#elif __CORTEX_M == (0x04U)
+#elif __CORTEX_M >= (0x04U)
 #define _PRIO_SD_HIGH       0
 #define _PRIO_SD_MID        1
 #define _PRIO_APP_HIGH      2
@@ -92,20 +92,20 @@ extern "C" {
 typedef enum
 {
 #ifndef SOFTDEVICE_PRESENT
-    APP_IRQ_PRIORITY_HIGHEST = _PRIO_SD_HIGH,
+    APP_IRQ_PRIORITY_HIGHEST = _PRIO_SD_HIGH,     /**< Running in Application Highest interrupt level. */
 #else
-    APP_IRQ_PRIORITY_HIGHEST = _PRIO_APP_HIGH,
+    APP_IRQ_PRIORITY_HIGHEST = _PRIO_APP_HIGH,    /**< Running in Application Highest interrupt level. */
 #endif
-    APP_IRQ_PRIORITY_HIGH    = _PRIO_APP_HIGH,
+    APP_IRQ_PRIORITY_HIGH    = _PRIO_APP_HIGH,    /**< Running in Application High interrupt level. */
 #ifndef SOFTDEVICE_PRESENT
-    APP_IRQ_PRIORITY_MID     = _PRIO_SD_LOW,
+    APP_IRQ_PRIORITY_MID     = _PRIO_SD_LOW,      /**< Running in Application Middle interrupt level. */
 #else
-    APP_IRQ_PRIORITY_MID     = _PRIO_APP_MID,
+    APP_IRQ_PRIORITY_MID     = _PRIO_APP_MID,     /**< Running in Application Middle interrupt level. */
 #endif
-    APP_IRQ_PRIORITY_LOW_MID = _PRIO_APP_LOW_MID,
-    APP_IRQ_PRIORITY_LOW     = _PRIO_APP_LOW,
-    APP_IRQ_PRIORITY_LOWEST  = _PRIO_APP_LOWEST,
-    APP_IRQ_PRIORITY_THREAD  = _PRIO_THREAD     /**< "Interrupt level" when running in Thread Mode. */
+    APP_IRQ_PRIORITY_LOW_MID = _PRIO_APP_LOW_MID, /**< Running in Application Middle Low interrupt level. */
+    APP_IRQ_PRIORITY_LOW     = _PRIO_APP_LOW,     /**< Running in Application Low interrupt level. */
+    APP_IRQ_PRIORITY_LOWEST  = _PRIO_APP_LOWEST,  /**< Running in Application Lowest interrupt level. */
+    APP_IRQ_PRIORITY_THREAD  = _PRIO_THREAD       /**< Running in Thread Mode. */
 } app_irq_priority_t;
 //lint -restore
 
@@ -255,10 +255,7 @@ void app_util_critical_region_exit (uint8_t nested);
 
 /**@brief Function for finding the current interrupt level.
  *
- * @return   Current interrupt level.
- * @retval   APP_IRQ_PRIORITY_HIGH    We are running in Application High interrupt level.
- * @retval   APP_IRQ_PRIORITY_LOW     We are running in Application Low interrupt level.
- * @retval   APP_IRQ_PRIORITY_THREAD  We are running in Thread Mode.
+ * @return   Current interrupt level. See @ref app_irq_priority_t for values.
  */
 uint8_t current_int_priority_get(void);
 

--- a/nRF5SDK/components/libraries/util/nordic_common.h
+++ b/nRF5SDK/components/libraries/util/nordic_common.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2008 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2008 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/nrf_assert.c
+++ b/nRF5SDK/components/libraries/util/nrf_assert.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2006 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2006 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/nrf_assert.h
+++ b/nRF5SDK/components/libraries/util/nrf_assert.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2006 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2006 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/nrf_bitmask.h
+++ b/nRF5SDK/components/libraries/util/nrf_bitmask.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2006 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2006 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/sdk_alloca.h
+++ b/nRF5SDK/components/libraries/util/sdk_alloca.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/sdk_common.h
+++ b/nRF5SDK/components/libraries/util/sdk_common.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2013 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/sdk_errors.h
+++ b/nRF5SDK/components/libraries/util/sdk_errors.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2013 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/sdk_macros.h
+++ b/nRF5SDK/components/libraries/util/sdk_macros.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2013 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/sdk_mapped_flags.h
+++ b/nRF5SDK/components/libraries/util/sdk_mapped_flags.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/sdk_os.h
+++ b/nRF5SDK/components/libraries/util/sdk_os.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2013 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/libraries/util/sdk_resources.h
+++ b/nRF5SDK/components/libraries/util/sdk_resources.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/softdevice/common/nrf_sdh.c
+++ b/nRF5SDK/components/softdevice/common/nrf_sdh.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/softdevice/common/nrf_sdh.h
+++ b/nRF5SDK/components/softdevice/common/nrf_sdh.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/softdevice/common/nrf_sdh_ant.h
+++ b/nRF5SDK/components/softdevice/common/nrf_sdh_ant.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/softdevice/common/nrf_sdh_ble.c
+++ b/nRF5SDK/components/softdevice/common/nrf_sdh_ble.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -136,12 +136,14 @@ ret_code_t nrf_sdh_ble_default_cfg_set(uint8_t conn_cfg_tag, uint32_t * p_ram_st
 
     // Configure the connection roles.
     memset(&ble_cfg, 0, sizeof(ble_cfg));
+#if !defined (S122)
     ble_cfg.gap_cfg.role_count_cfg.periph_role_count  = NRF_SDH_BLE_PERIPHERAL_LINK_COUNT;
+#endif // !defined (S122)
 #if !defined (S112) && !defined(S312) && !defined(S113)
     ble_cfg.gap_cfg.role_count_cfg.central_role_count = NRF_SDH_BLE_CENTRAL_LINK_COUNT;
     ble_cfg.gap_cfg.role_count_cfg.central_sec_count  = MIN(NRF_SDH_BLE_CENTRAL_LINK_COUNT,
                                                             BLE_GAP_ROLE_COUNT_CENTRAL_SEC_DEFAULT);
-#endif
+#endif // !defined (S112) && !defined(S312) && !defined(S113)
 
     ret_code = sd_ble_cfg_set(BLE_GAP_CFG_ROLE_COUNT, &ble_cfg, *p_ram_start);
     if (ret_code != NRF_SUCCESS)

--- a/nRF5SDK/components/softdevice/common/nrf_sdh_ble.h
+++ b/nRF5SDK/components/softdevice/common/nrf_sdh_ble.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/softdevice/common/nrf_sdh_freertos.h
+++ b/nRF5SDK/components/softdevice/common/nrf_sdh_freertos.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/softdevice/common/nrf_sdh_soc.c
+++ b/nRF5SDK/components/softdevice/common/nrf_sdh_soc.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/softdevice/common/nrf_sdh_soc.h
+++ b/nRF5SDK/components/softdevice/common/nrf_sdh_soc.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/components/softdevice/s140/headers/nrf_sd_def.h
+++ b/nRF5SDK/components/softdevice/s140/headers/nrf_sd_def.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -41,15 +41,27 @@
 #define NRF_SD_DEF_H__
 
 #include <stdint.h>
+#include "nrf_soc.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define SD_PPI_CHANNELS_USED            0xFFFE0000uL /**< PPI channels utilized by SotfDevice (not available to the application). */
-#define SD_PPI_GROUPS_USED              0x0000000CuL /**< PPI groups utilized by SoftDevice (not available to the application). */
-#define SD_TIMERS_USED                  0x00000001uL /**< Timers used by SoftDevice. */
-#define SD_SWI_USED                     0x0000003CuL /**< Software interrupts used by SoftDevice */
+
+#ifdef NRF_SOC_SD_PPI_CHANNELS_SD_ENABLED_MSK
+#define SD_PPI_CHANNELS_USED    NRF_SOC_SD_PPI_CHANNELS_SD_ENABLED_MSK /**< PPI channels utilized by SotfDevice (not available to the application). */
+#else
+#define SD_PPI_CHANNELS_USED    0xFFFE0000uL                           /**< PPI channels utilized by SotfDevice (not available to the application). */
+#endif // NRF_SOC_SD_PPI_CHANNELS_SD_ENABLED_MSK
+
+#ifdef NRF_SOC_SD_PPI_GROUPS_SD_ENABLED_MSK
+#define SD_PPI_GROUPS_USED      NRF_SOC_SD_PPI_GROUPS_SD_ENABLED_MSK /**< PPI groups utilized by SoftDevice (not available to the application). */
+#else
+#define SD_PPI_GROUPS_USED      0x0000000CuL                         /**< PPI groups utilized by SoftDevice (not available to the application). */
+#endif // NRF_SOC_SD_PPI_GROUPS_SD_ENABLED_MSK
+
+#define SD_TIMERS_USED          0x00000001uL /**< Timers used by SoftDevice. */
+#define SD_SWI_USED             0x00000036uL /**< Software interrupts used by SoftDevice */
 
 
 #ifdef __cplusplus

--- a/nRF5SDK/external/fprintf/nrf_fprintf.c
+++ b/nRF5SDK/external/fprintf/nrf_fprintf.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK/external/fprintf/nrf_fprintf.h
+++ b/nRF5SDK/external/fprintf/nrf_fprintf.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK_mods/app_timer2.c
+++ b/nRF5SDK_mods/app_timer2.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -296,7 +296,7 @@ static void on_compare_evt(drv_rtc_t const * const  p_instance)
     {
         /* If assert fails it suggests that safe window should be increased. */
         ASSERT(app_timer_cnt_diff_compute(drv_rtc_counter_get(p_instance),
-                                          mp_active_timer->end_val & RTC_COUNTER_COUNTER_Msk) < APP_TIMER_SAFE_WINDOW);
+                                          drv_rtc_compare_get(p_instance, 0)) < APP_TIMER_SAFE_WINDOW);
 
         NRF_LOG_INST_DEBUG(mp_active_timer->p_log, "Compare EVT");
         UNUSED_RETURN_VALUE(timer_expire(mp_active_timer));

--- a/nRF5SDK_mods/ble_dfu_bonded.c
+++ b/nRF5SDK_mods/ble_dfu_bonded.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK_mods/drv_rtc.c
+++ b/nRF5SDK_mods/drv_rtc.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2018 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -330,6 +330,11 @@ bool drv_rtc_compare_pending(drv_rtc_t const * const p_instance, uint32_t cc)
 {
     nrf_rtc_event_t cc_evt = CC_IDX_TO_CC_EVENT(cc);
     return evt_pending(p_instance, cc_evt);
+}
+
+uint32_t drv_rtc_compare_get(drv_rtc_t const * const p_instance, uint32_t cc)
+{
+    return nrf_rtc_cc_get(p_instance->p_reg, cc);
 }
 
 uint32_t drv_rtc_counter_get(drv_rtc_t const * const p_instance)

--- a/nRF5SDK_mods/nrf_pwr_mgmt.c
+++ b/nRF5SDK_mods/nrf_pwr_mgmt.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK_mods/nrf_sdh_soc.c
+++ b/nRF5SDK_mods/nrf_sdh_soc.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *

--- a/nRF5SDK_mods/nrf_sdh_soc.h
+++ b/nRF5SDK_mods/nrf_sdh_soc.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2017 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *


### PR DESCRIPTION
I unpacked the zip, nRF5_SDK_17.0.0_9d13099 and compared it with SDK 16. Then I deleted the files not in this repo, moved the files matching our mods into a separate folder, and compared and merged the changes.

I've split the merge into a few commits to make it easier to examine the actual changes. There aren't many! There are 161 modified files, but over 130 of those only change the copyright date.


**Comparing nRF5_SDK_17.0.0_9d13099 with nRF5SDK 16.0.0 (nRF5SDK160098a08e2)**

- nRF5SDK 17.0.0 has upgraded nrfx version 1.8.0 to 1.8.4 with MDK updated to version 8.32.1. I haven't examined what changed because we are not using the SDK's nrfx.

- I don't know if this is significant... In config/nrf52833/armgcc/generic_gcc_nrf52.ld, .sdh_req_observers has moved above .sdh_state_observers. I haven't changed our linker script.

- Softdevice S140 is identical: s140_nrf52_7.0.1_softdevice.hex



**nRF5SDK_mods**

There are some minor changes in a couple of our modified files, but none that make the mods unnecessary or unsuitable.
See https://github.com/microbit-foundation/codal-microbit-nrf5sdk/commit/997e35648e1edb3f50d6e83aa4cefa39f544eb26

Summarising the reasons for the mods:

- For nrfx version incompatibility
app_timer2.c		codal-nrf52 has different values for NRFX_SUCCESS & NRF_SUCCESS
drv_rtc.c			nrfx 2.0.0 doesn't have nrf_rtc_event_pending
nrf_pwr_mgmt.c	nrf_power_system_off needs a parameter

- For build system incompatibility
nrf_sdh_soc.c/h	Add a function to avoid whole file being optimised away when linked from a library

- To use MICROBIT_BLE_SECURITY_MODE in the buttonless DFU service
ble_dfu_bonded.c

- Implementation of DMESG backend for nrf_log (strictly an addition rather than a mod)
nrf_log_backend_dmesg.c/h
