### PR TITLE
Use S140 driver on demand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ list(APPEND INCLUDE_SDK_DIRS
     "${SDK_DIRECTORY}/nRF5SDK/components/libraries/bootloader"
     "${SDK_DIRECTORY}/nRF5SDK/components/libraries/fstorage"
     "${SDK_DIRECTORY}/nRF5SDK/components/libraries/experimental_section_vars"
-    "${SDK_DIRECTORY}/nRF5SDK/components/softdevice/s113/headers"
+    "${SDK_DIRECTORY}/nRF5SDK/components/softdevice"
     "${SDK_DIRECTORY}/nRF5SDK/components/libraries/mutex"
     "${SDK_DIRECTORY}/nRF5SDK/components/libraries/delay"
     "${SDK_DIRECTORY}/nRF5SDK/components/libraries/bootloader/ble_dfu"
@@ -89,7 +89,6 @@ endif()
 list(APPEND INCLUDE_SDK_DIRS
     "${SDK_DIRECTORY}/nRF5SDK/components/libraries/fds"
     "${SDK_DIRECTORY}/nRF5SDK/components/libraries/atomic_flags"
-    "${SDK_DIRECTORY}/nRF5SDK/components/softdevice/s113/headers/nrf52"
     "${SDK_DIRECTORY}/nRF5SDK/components/ble/ble_services/ble_dfu"
 )
 

--- a/nRF5SDK/components/softdevice/ble.h
+++ b/nRF5SDK/components/softdevice/ble.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble.h"
+#endif

--- a/nRF5SDK/components/softdevice/ble_err.h
+++ b/nRF5SDK/components/softdevice/ble_err.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble_err.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble_err.h"
+#endif

--- a/nRF5SDK/components/softdevice/ble_gap.h
+++ b/nRF5SDK/components/softdevice/ble_gap.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble_gap.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble_gap.h"
+#endif

--- a/nRF5SDK/components/softdevice/ble_gatt.h
+++ b/nRF5SDK/components/softdevice/ble_gatt.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble_gatt.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble_gatt.h"
+#endif

--- a/nRF5SDK/components/softdevice/ble_gattc.h
+++ b/nRF5SDK/components/softdevice/ble_gattc.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble_gattc.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble_gattc.h"
+#endif

--- a/nRF5SDK/components/softdevice/ble_gatts.h
+++ b/nRF5SDK/components/softdevice/ble_gatts.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble_gatts.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble_gatts.h"
+#endif

--- a/nRF5SDK/components/softdevice/ble_hci.h
+++ b/nRF5SDK/components/softdevice/ble_hci.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble_hci.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble_hci.h"
+#endif

--- a/nRF5SDK/components/softdevice/ble_l2cap.h
+++ b/nRF5SDK/components/softdevice/ble_l2cap.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble_l2cap.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble_l2cap.h"
+#endif

--- a/nRF5SDK/components/softdevice/ble_ranges.h
+++ b/nRF5SDK/components/softdevice/ble_ranges.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble_ranges.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble_ranges.h"
+#endif

--- a/nRF5SDK/components/softdevice/ble_types.h
+++ b/nRF5SDK/components/softdevice/ble_types.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/ble_types.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/ble_types.h"
+#endif

--- a/nRF5SDK/components/softdevice/nrf_error.h
+++ b/nRF5SDK/components/softdevice/nrf_error.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/nrf_error.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/nrf_error.h"
+#endif

--- a/nRF5SDK/components/softdevice/nrf_error_sdm.h
+++ b/nRF5SDK/components/softdevice/nrf_error_sdm.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/nrf_error_sdm.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/nrf_error_sdm.h"
+#endif

--- a/nRF5SDK/components/softdevice/nrf_error_soc.h
+++ b/nRF5SDK/components/softdevice/nrf_error_soc.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/nrf_error_soc.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/nrf_error_soc.h"
+#endif

--- a/nRF5SDK/components/softdevice/nrf_mbr.h
+++ b/nRF5SDK/components/softdevice/nrf_mbr.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/nrf52/nrf_mbr.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/nrf52/nrf_mbr.h"
+#endif

--- a/nRF5SDK/components/softdevice/nrf_nvic.h
+++ b/nRF5SDK/components/softdevice/nrf_nvic.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/nrf_nvic.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/nrf_nvic.h"
+#endif

--- a/nRF5SDK/components/softdevice/nrf_sd_def.h
+++ b/nRF5SDK/components/softdevice/nrf_sd_def.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/nrf_sd_def.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/nrf_sd_def.h"
+#endif

--- a/nRF5SDK/components/softdevice/nrf_sdm.h
+++ b/nRF5SDK/components/softdevice/nrf_sdm.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/nrf_sdm.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/nrf_sdm.h"
+#endif

--- a/nRF5SDK/components/softdevice/nrf_soc.h
+++ b/nRF5SDK/components/softdevice/nrf_soc.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/nrf_soc.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/nrf_soc.h"
+#endif

--- a/nRF5SDK/components/softdevice/nrf_svc.h
+++ b/nRF5SDK/components/softdevice/nrf_svc.h
@@ -1,0 +1,8 @@
+
+#ifdef S140
+#include "s140/headers/nrf_svc.h"
+#endif
+
+#ifdef S113
+#include "s113/headers/nrf_svc.h"
+#endif


### PR DESCRIPTION

Hi there,

For our project we need to put the microbit in Central mode (BLE). As it is not possible to do this via the current drivers (S113) we would need to use the S140 drivers instead.

According to what we found on the different microbit repos (issue, pull-request, ...), it is difficult (impossible ?) to change the BLE drivers without modifying the whole compilation chain and impacting everyone.

That's why we propose this solution:
  - Add "proxy" files, which will include the right .h files (S113 or S140). The selection of the files is done via the `-D` option in the build parameters (by default, on microbit there is `-DS113`, so these are included by default).
  - The CMakeList.txt no longer contains direct access to the file for the S113, but to our "proxy" files.

Finally, to use the S140 drivers, you just need to add the line `"S140": 1` in the `pxt.json` file for a microbit extension, or to add `-DS140` in the build chain. The inclusion of S140 files takes precedence over S113 in case **both** are defined.

Example of our "yotta part" in [`pxt.json`](https://github.com/letssteam/pxt-magnetics-microbit/blob/main/pxt.json) file  for the extension we are developing:
```json
"yotta": {
    "config": {
        "microbit-dal": {
            "bluetooth": {
                "open": 0,
                "whitelist": 0,
                "security_level": null
            }
        },
        "S140": 1
    }
}
```

Some microbit users would like to have access to this feature ([https://github.com/lancaster-university/codal-microbit-v2/issues/212](https://github.com/lancaster-university/codal-microbit-v2/issues/212)).

This solution has the advantage of not impacting current microbit users, as the operation remains the same, but offers the possibility of using the S140 drivers for more BLE functionality.

I hope I have made myself clear,

Jonathan.