### PR TITLE
Suppress all warnings from this target as it's 3rd party code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,3 +267,6 @@ target_link_libraries(
 # expose it to parent cmake.
 target_include_directories(codal-microbit-nrf5sdk PUBLIC ${INCLUDE_DIRS})
 target_include_directories(codal-microbit-nrf5sdk PUBLIC ${INCLUDE_SDK_DIRS})
+
+# Suppress all warnings from this SDK as this is third party code
+target_compile_options(codal-microbit-nrf5sdk PRIVATE -w)


### PR DESCRIPTION
As we are not going to touch the SDK files unless strictly necessary, and even then only through modded files.

This way we don't get a lot of warnings when compiling the microbit-v2 target, and accidentally missed important warnings from all the noise.