### PR TITLE
Eliminate fallthrough and pointer warnings

### DIFF
--- a/nRF5SDK/components/ble/peer_manager/gatt_cache_manager.c
+++ b/nRF5SDK/components/ble/peer_manager/gatt_cache_manager.c
@@ -382,6 +382,7 @@ static void service_changed_send_in_evt(uint16_t conn_handle)
             }
         }
             // Sometimes fallthrough.
+        [[fallthrough]];
         case NRF_ERROR_NOT_SUPPORTED:
             // Service changed not supported. Drop indication.
             sc_pending_state = false;

--- a/nRF5SDK/components/libraries/fds/fds.c
+++ b/nRF5SDK/components/libraries/fds/fds.c
@@ -1266,7 +1266,7 @@ static ret_code_t write_execute(uint32_t prev_ret, fds_op_t * const p_op)
             // Setting the step is redundant since we are falling through.
         }
         // Fallthrough to FDS_OP_WRITE_HEADER_BEGIN.
-
+        [[ fallthrough ]];
         case FDS_OP_WRITE_HEADER_BEGIN:
             ret = record_header_write_begin(p_op, p_write_addr);
             break;

--- a/nRF5SDK/components/libraries/fstorage/nrf_fstorage.c
+++ b/nRF5SDK/components/libraries/fstorage/nrf_fstorage.c
@@ -195,6 +195,11 @@ uint8_t * nrf_fstorage_wmap(nrf_fstorage_t const * p_fs, uint32_t addr)
 
 bool nrf_fstorage_is_busy(nrf_fstorage_t const * p_fs)
 {
+// NRF_FSTORAGE_INSTANCE_GET(i) is not currently compatible with -Warray-bounds,
+// as gcc infers a size of only 4 bytes for the __start_fs_data symbol used in
+// that macro.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
     /* If a NULL instance is provided, return true if any instance is busy.
      * Uninitialized instances are considered not busy. */
     if ((p_fs == NULL) || (p_fs->p_api == NULL))
@@ -216,6 +221,7 @@ bool nrf_fstorage_is_busy(nrf_fstorage_t const * p_fs)
     }
 
     return p_fs->p_api->is_busy(p_fs);
+#pragma GCC diagnostic push
 }
 
 


### PR DESCRIPTION
Add appropriate attributes to eliminate switch fallthrough warnings.

Add a pragma to disable what seems to be a harmless gcc warning related to the pointer of unknown size for __start_fs_data, related to the fs_data section.